### PR TITLE
Fix: Corregir ReferenceError por esSocioValidado en BookingPage

### DIFF
--- a/src/pages/BookingPage.jsx
+++ b/src/pages/BookingPage.jsx
@@ -49,7 +49,7 @@ function BookingPage() {
       setDuracionCalculada(0);
       setCostoCalculado(0);
     }
-  }, [salonSeleccionado, horaInicio, horaTermino, esSocioValidado]);
+  }, [salonSeleccionado, horaInicio, horaTermino, socioData]); // Corregido: esSocioValidado -> socioData
   
   const handleValidationSuccess = (datosSocio) => { // Renombrado parámetro para claridad
     setNombreSocio(datosSocio.nombre_completo);


### PR DESCRIPTION
Se corrigió una referencia incorrecta a `esSocioValidado` en el array de dependencias de un `useEffect` en `src/pages/BookingPage.jsx`. La variable correcta es `socioData` después de la refactorización previa. Esto resuelve el error que causaba una página en blanco.