### PR TITLE
Fix: Use date-fns to parse API dates as local

### DIFF
--- a/src/components/Paso2_SeleccionFecha.jsx
+++ b/src/components/Paso2_SeleccionFecha.jsx
@@ -1,14 +1,15 @@
 import React, { useState, useEffect } from 'react';
-// import axios from 'axios'; // Ya no se usa axios directamente
-import api from '../api'; // <-- IMPORTAMOS NUESTRA INSTANCIA CENTRALIZADA
+import api from '../api';
 import CustomCalendar from './CustomCalendar';
 import './Paso2_SeleccionFecha.css';
+import { parse as parseDate, format as formatDate } from 'date-fns'; // Renamed to avoid conflict
 
 function Paso2_SeleccionFecha({ salonSeleccionado, fechaSeleccionada, setFechaSeleccionada, nextStep, prevStep }) {
   const [disponibilidadMensual, setDisponibilidadMensual] = useState({});
   const [mesCalendario, setMesCalendario] = useState(fechaSeleccionada || new Date());
 
-  const formatearFechaParaAPI = (date) => date ? date.toISOString().split('T')[0] : '';
+  // Updated to use date-fns
+  const formatearFechaParaAPI = (date) => date ? formatDate(date, 'yyyy-MM-dd') : '';
   
   useEffect(() => {
     if (salonSeleccionado) {
@@ -24,7 +25,9 @@ function Paso2_SeleccionFecha({ salonSeleccionado, fechaSeleccionada, setFechaSe
         const disponibilidadProcesada = {};
         const totalBloquesPorDia = 9;
         response.data.forEach(reserva => {
-          const fecha = formatearFechaParaAPI(new Date(reserva.fecha_reserva));
+          // Parse reserva.fecha_reserva (e.g., '2023-10-26') as a local date
+          const fechaDateObj = parseDate(reserva.fecha_reserva, 'yyyy-MM-dd', new Date());
+          const fecha = formatearFechaParaAPI(fechaDateObj); // Convert back to 'yyyy-MM-dd' string for key
           if (!disponibilidadProcesada[fecha]) {
             disponibilidadProcesada[fecha] = { ocupados: 0, totalBloques: totalBloquesPorDia };
           }

--- a/src/components/ReservasManager.jsx
+++ b/src/components/ReservasManager.jsx
@@ -3,7 +3,8 @@ import React, { useState, useEffect, useCallback } from 'react';
 import api from '../api';
 import EditReservationModal from './EditReservationModal';
 import DatePicker, { registerLocale } from 'react-datepicker';
-import es from 'date-fns/locale/es';
+import { es } from 'date-fns/locale'; // Import specific locale
+import { parse, format } from 'date-fns'; // Import parse and format
 import 'react-datepicker/dist/react-datepicker.css';
 import useDebounce from '../hooks/useDebounce';
 
@@ -101,7 +102,17 @@ function ReservasManager() {
   const handleUpdateReservation = (updatedReserva) => { 
     setReservas(reservas.map(reserva => reserva.id === updatedReserva.id ? updatedReserva : reserva)); 
   };
-  const formatearFecha = (fechaISO) => { const opciones = { year: 'numeric', month: 'long', day: 'numeric' }; return new Date(fechaISO).toLocaleDateString('es-CL', opciones); };
+  // const formatearFecha = (fechaISO) => { const opciones = { year: 'numeric', month: 'long', day: 'numeric' }; return new Date(fechaISO).toLocaleDateString('es-CL', opciones); };
+  const formatearFecha = (fechaISO) => {
+    // Assuming fechaISO is 'YYYY-MM-DD'
+    try {
+      const date = parse(fechaISO, 'yyyy-MM-dd', new Date());
+      return format(date, 'PPP', { locale: es }); // 'PPP' is a long date format, e.g., "1 de ene. de 2023"
+    } catch (e) {
+      console.error("Error parsing date:", fechaISO, e);
+      return fechaISO; // Fallback to original string if parsing fails
+    }
+  };
   
   const handleCancelReserva = async (reservaId) => {
     if (!window.confirm(`¿Estás seguro de que deseas cancelar la reserva con ID ${reservaId}?`)) return;


### PR DESCRIPTION
Replaced instances of `new Date('YYYY-MM-DD')` with `date-fns/parse` to ensure that date strings from the API (in 'YYYY-MM-DD' format) are interpreted as local dates, preventing off-by-one day errors caused by JavaScript's default UTC parsing.

Updated date formatting to use `date-fns/format` for consistency in `ReservasManager` and `Paso2_SeleccionFecha` components.