### PR TITLE
Fix: Reverse admin reservation sort order based on feedback

### DIFF
--- a/src/components/ReservasManager.jsx
+++ b/src/components/ReservasManager.jsx
@@ -47,7 +47,7 @@ function ReservasManager() {
       const sortedReservas = response.data.reservas.sort((a, b) => {
         const dateA = parse(a.fecha_reserva, 'yyyy-MM-dd', new Date());
         const dateB = parse(b.fecha_reserva, 'yyyy-MM-dd', new Date());
-        return dateA - dateB;
+        return dateB - dateA; // Reversed to sort descending (latest first)
       });
 
       setReservas(sortedReservas);


### PR DESCRIPTION
Changed the sort order for reservations in the admin panel to be descending (latest dates first). This is an attempt to match the user's expectation of 'closest date first' after previous attempts to sort ascending did not meet the requirement.