### PR TITLE
Fix: Revert to ascending sort for admin reservations

### DIFF
--- a/src/components/ReservasManager.jsx
+++ b/src/components/ReservasManager.jsx
@@ -47,7 +47,7 @@ function ReservasManager() {
       const sortedReservas = response.data.reservas.sort((a, b) => {
         const dateA = parse(a.fecha_reserva, 'yyyy-MM-dd', new Date());
         const dateB = parse(b.fecha_reserva, 'yyyy-MM-dd', new Date());
-        return dateB - dateA; // Reversed to sort descending (latest first)
+        return dateA - dateB; // Sort ascending (earliest first)
       });
 
       setReservas(sortedReservas);


### PR DESCRIPTION
Reverted the sort order for reservations in the admin panel to be ascending (earliest dates first), as per user clarification on the desired order.

The comparison `dateA - dateB` is used, which correctly sorts dates from past to future.