### PR TITLE
feat: Implementar botones separados para Ver Detalles y Cambiar Estad…

### DIFF
--- a/src/components/EditReservationModal.css
+++ b/src/components/EditReservationModal.css
@@ -98,7 +98,51 @@
 .modal-body .form-group {
     margin-top: 15px; /* Reducido margen superior para grupos de formulario */
 }
-.modal-body .form-group label {
+
+.estado-section {
+  margin-bottom: 20px;
+  padding: 10px;
+  background-color: #f8f9fa;
+  border-radius: var(--border-radius-md);
+  border: 1px solid var(--border-color-light);
+}
+.estado-section h4 {
+  font-size: 1.1em;
+  color: var(--color-indigo-600);
+  margin-top: 0;
+  margin-bottom: 10px;
+  padding-bottom: 5px;
+  border-bottom: 1px solid var(--color-indigo-100);
+}
+.estado-section p {
+  font-size: 1em;
+  margin-bottom: 5px;
+}
+
+
+.form-group-estado { /* Para el select de estado cuando está en modo edición */
+  margin-top: 15px;
+  margin-bottom: 20px;
+}
+
+.form-group-estado label {
+    font-weight: 600;
+    margin-bottom: 8px;
+    display: block;
+    color: var(--color-gray-700);
+}
+.form-group-estado select {
+    width: 100%;
+    padding: 10px;
+    border: 1px solid var(--border-color-default);
+    border-radius: 6px;
+    font-size: 1em;
+    font-family: inherit;
+    background-color: var(--color-white); /* Fondo blanco para el select en modo edición */
+}
+
+
+.modal-body .form-group label { /* Estilos generales para labels si los hubiera fuera de .form-group-estado */
     font-weight: 600;
     margin-bottom: 8px;
     display: block;

--- a/src/components/ReservasManager.jsx
+++ b/src/components/ReservasManager.jsx
@@ -23,6 +23,7 @@ function ReservasManager() {
   const [totalPages, setTotalPages] = useState(0);
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [editingReservation, setEditingReservation] = useState(null);
+  const [modalInitialMode, setModalInitialMode] = useState('view'); // 'view' o 'edit'
 
   const formatearFechaParaAPI = (date) => date ? date.toISOString().split('T')[0] : null;
 
@@ -112,8 +113,25 @@ function ReservasManager() {
     return [...new Set(items)];
   };
 
-  const handleOpenEditModal = (reserva) => { setEditingReservation(reserva); setIsModalOpen(true); };
-  const handleCloseModal = () => { setIsModalOpen(false); setEditingReservation(null); };
+  // const handleOpenEditModal = (reserva) => { setEditingReservation(reserva); setIsModalOpen(true); };
+  const handleOpenViewModal = (reserva) => {
+    setEditingReservation(reserva);
+    setModalInitialMode('view');
+    setIsModalOpen(true);
+  };
+
+  const handleOpenEditStateModal = (reserva) => {
+    setEditingReservation(reserva);
+    setModalInitialMode('edit');
+    setIsModalOpen(true);
+  };
+
+  const handleCloseModal = () => {
+    setIsModalOpen(false);
+    setEditingReservation(null);
+    // No es necesario resetear modalInitialMode aquí, se setea antes de abrir.
+  };
+
   const handleUpdateReservation = (updatedReserva) => { 
     setReservas(reservas.map(reserva => reserva.id === updatedReserva.id ? updatedReserva : reserva)); 
   };
@@ -237,9 +255,10 @@ function ReservasManager() {
                     </td>
                     <td>{reserva.tipo_documento ? reserva.tipo_documento.charAt(0).toUpperCase() + reserva.tipo_documento.slice(1) : 'N/A'}</td>
                     <td><span className={`status-badge status-${reserva.estado_reserva}`}>{reserva.estado_reserva.replace(/_/g, ' ')}</span></td>
-                    <td>
-                      <button onClick={() => handleOpenEditModal(reserva)} className="action-button edit">Ver/Editar</button> {/* Cambiado texto botón */}
-                      <button onClick={() => handleCancelReserva(reserva.id)} className="action-button cancel" disabled={reserva.estado_reserva.includes('cancelada')}>Cancelar</button>
+                    <td className="actions-cell">
+                      <button onClick={() => handleOpenViewModal(reserva)} className="action-button view">Ver Detalles</button>
+                      <button onClick={() => handleOpenEditStateModal(reserva)} className="action-button edit-state">Cambiar Estado</button>
+                      <button onClick={() => handleCancelReserva(reserva.id)} className="action-button cancel" disabled={reserva.estado_reserva.includes('cancelada')}>Cancelar Reserva</button>
                     </td>
                   </tr>
                 ))
@@ -260,7 +279,14 @@ function ReservasManager() {
             <button onClick={() => handlePageChange(currentPage + 1)} disabled={currentPage === totalPages} className="pagination-btn arrow">Siguiente</button>
         </div>
       )}
-      {isModalOpen && (<EditReservationModal reserva={editingReservation} onClose={handleCloseModal} onUpdate={handleUpdateReservation} />)}
+      {isModalOpen && (
+        <EditReservationModal
+          reserva={editingReservation}
+          onClose={handleCloseModal}
+          onUpdate={handleUpdateReservation}
+          initialMode={modalInitialMode} // Pasar el modo inicial
+        />
+      )}
     </>
   );
 }

--- a/src/pages/AdminDashboardPage.css
+++ b/src/pages/AdminDashboardPage.css
@@ -248,9 +248,22 @@
   background-color: #e0e7ff;
   color: #3730a3;
 }
-.action-button.edit:hover {
+.action-button.edit:hover,
+.action-button.edit-state:hover {
   background-color: #c7d2fe;
 }
+.action-button.view { /* Nuevo estilo para el botón "Ver Detalles" */
+  background-color: #e5e7eb; /* Gris claro */
+  color: #374151; /* Gris oscuro */
+}
+.action-button.view:hover {
+  background-color: #d1d5db; /* Gris un poco más oscuro al pasar el mouse */
+}
+.action-button.edit-state { /* Estilo para el nuevo botón "Cambiar Estado" */
+  background-color: #fef3c7; /* Amarillo claro, similar a pendiente */
+  color: #92400e; /* Naranja oscuro */
+}
+
 .action-button.cancel {
   background-color: #fee2e2;
   color: #b91c1c;


### PR DESCRIPTION
…o en admin

- En `ReservasManager.jsx`:
  - Reemplaza el botón único "Ver/Editar" por dos botones explícitos: "Ver Detalles" y "Cambiar Estado" en la tabla de acciones.
  - Añade un estado `modalInitialMode` para controlar cómo se abre el modal.
  - Las funciones `handleOpenViewModal` y `handleOpenEditStateModal` ahora establecen este modo y lo pasan como prop `initialMode` a `EditReservationModal`.
- En `EditReservationModal.jsx`:
  - Acepta la nueva prop `initialMode`.
  - El estado `modoEdicionEstado` se inicializa basado en `initialMode`.
  - Si `initialMode` es 'view', el modal se abre en modo solo lectura; un botón interno "Modificar Estado" permite cambiar a modo edición.
  - Si `initialMode` es 'edit', el modal se abre directamente en modo de edición de estado.
  - Ajusta la lógica de los botones del pie de página del modal según el modo.
- Actualiza estilos CSS para los nuevos botones en la tabla de administración.