### PR TITLE
style: Ajustes finales de UX y CSS para modal de admin

### DIFF
--- a/src/components/EditReservationModal.css
+++ b/src/components/EditReservationModal.css
@@ -42,11 +42,14 @@
 }
 
 .modal-body {
-  margin-bottom: 30px;
+  margin-bottom: 20px; /* Reducido para compensar el padding del scrollbar si es necesario */
+  padding-right: 15px; /* Espacio para el scrollbar si aparece, para que no tape contenido */
+  max-height: 70vh;   /* Altura máxima antes de que aparezca el scroll */
+  overflow-y: auto;   /* Scroll vertical solo cuando sea necesario */
 }
 .modal-body p {
-    margin: 0 0 8px 0; /* Reducido margen inferior para párrafos de info */
-    font-size: 1em; /* Ligeramente más pequeño */
+    margin: 0 0 8px 0;
+    font-size: 1em;
     line-height: 1.5;
 }
 

--- a/src/pages/AdminDashboardPage.css
+++ b/src/pages/AdminDashboardPage.css
@@ -259,9 +259,12 @@
 .action-button.view:hover {
   background-color: #d1d5db; /* Gris un poco más oscuro al pasar el mouse */
 }
-.action-button.edit-state { /* Estilo para el nuevo botón "Cambiar Estado" */
-  background-color: #fef3c7; /* Amarillo claro, similar a pendiente */
-  color: #92400e; /* Naranja oscuro */
+.action-button.edit-state { /* Estilo para el botón "Editar" (antes Cambiar Estado) */
+  background-color: #DBEAFE; /* Azul claro (Tailwind blue-100) */
+  color: #1E40AF; /* Azul oscuro (Tailwind blue-800) */
+}
+.action-button.edit-state:hover {
+  background-color: #BFDBFE; /* Azul un poco más oscuro (Tailwind blue-200) */
 }
 
 .action-button.cancel {


### PR DESCRIPTION
- Cambia el color del botón "Editar" en la tabla de ReservasManager a un tono azulado para consistencia visual.
- Añade `max-height` y `overflow-y: auto` al cuerpo del EditReservationModal (`.modal-body`) para permitir scroll vertical cuando el contenido es extenso, mejorando la visualización de todos los detalles de la reserva.