### PR TITLE
style: Simplificar visualización de precios en SalonCard

### DIFF
--- a/src/components/SalonCard.jsx
+++ b/src/components/SalonCard.jsx
@@ -103,7 +103,7 @@ function SalonCard({ salon, onSelect, isSelected, esSocio }) {
           <div style={{ textAlign: 'right' }}>
             {esSocio && (
               <span className="price-tag" style={{ color: '#DC2626', display: 'block' }}>
-                ${precioTotalSocioFormateado}/hr (IVA incl.)
+                ${precioTotalSocioFormateado}/hr
               </span>
             )}
             <span 
@@ -115,12 +115,12 @@ function SalonCard({ salon, onSelect, isSelected, esSocio }) {
                 fontSize: esSocio ? '0.9em' : '1.125em'
               }}
             >
-              ${precioTotalNormalFormateado}/hr (IVA incl.)
+              ${precioTotalNormalFormateado}/hr
             </span>
           </div>
         </div>
         <div className="price-breakdown-hint">
-          *Precios por hora con IVA incluido. El desglose se mostrará al reservar.
+          *Precios por hora con IVA incluido.
         </div>
         <div className="comodidades-section">
           <h4 className="comodidades-title">Comodidades:</h4>


### PR DESCRIPTION
- Acorta el texto de aclaración del IVA a "*Precios por hora con IVA incluido."
- Elimina el sufijo "(IVA incl.)" de los precios por hora mostrados en la tarjeta para una presentación más limpia.