### PR TITLE
Fix: Corrige la URL de la API para obtener cupones

### DIFF
--- a/src/components/CuponesManager.jsx
+++ b/src/components/CuponesManager.jsx
@@ -42,8 +42,8 @@ function CuponesManager() {
       if (activo) params.activo = activo;
       if (codigo) params.busqueda_codigo = codigo; // O el nombre del param que espere el backend
 
-      // Asegúrate que la ruta '/admin/cupones' sea la correcta para tu API de administrador
-      const response = await api.get('/admin/cupones', { params });
+      // Asegúrate que la ruta '/cupones' sea la correcta para tu API
+      const response = await api.get('/cupones', { params });
 
       // Asumiendo que la respuesta del backend tiene la forma:
       // { cupones: [...], totalPages: X, currentPage: Y }


### PR DESCRIPTION
La llamada a la API para obtener la lista de cupones en el panel de administración estaba utilizando una ruta incorrecta (`/admin/cupones`) en lugar de la esperada (`/cupones`).

Este cambio actualiza la ruta en `CuponesManager.jsx` para que coincida con la definición del backend, que es `[API_BASE_URL]/cupones`.

Se verifica que se utiliza la variable de entorno `VITE_API_URL` para la URL base de la API, como es recomendado.