### PR TITLE
Feat: Añade imagen principal con lazy loading a SalonCard

### DIFF
--- a/src/components/SalonCard.css
+++ b/src/components/SalonCard.css
@@ -4,6 +4,15 @@
    ESTRUCTURA GENERAL DE LA TARJETA
    ================================= */
 
+.card-main-image {
+  width: 100%;
+  height: 180px; /* Altura deseada para la imagen principal */
+  object-fit: cover; /* Asegura que la imagen cubra el área sin distorsionarse */
+  border-top-left-radius: 0.75rem; /* Coincide con el radio de la tarjeta */
+  border-top-right-radius: 0.75rem; /* Coincide con el radio de la tarjeta */
+  display: block; /* Elimina espacio extra debajo de la imagen si es inline */
+}
+
 .salon-card {
     background-color: white;
     border-radius: 0.75rem;

--- a/src/components/SalonCard.jsx
+++ b/src/components/SalonCard.jsx
@@ -81,6 +81,15 @@ function SalonCard({ salon, onSelect, isSelected, esSocio }) {
         onClick={handleSelectSalon} // Clic en la tarjeta general selecciona el salón
         style={cssVariables}
       >
+        {/* Mostrar la imagen principal del salón si está disponible */}
+        {salon.fotos && salon.fotos.length > 0 && salon.fotos[0].url && (
+          <img
+            src={salon.fotos[0].url}
+            alt={`Imagen de ${salon.nombre}`}
+            className="card-main-image"
+            loading="lazy"
+          />
+        )}
         {/* El div del header ahora solo es responsable de abrir la galería */}
         <div
           className="card-header"


### PR DESCRIPTION
Se modifica `SalonCard.jsx` para mostrar la primera imagen de la galería del salón directamente en la tarjeta, en la parte superior. Esta imagen utiliza el atributo `loading="lazy"` para mejorar el rendimiento de carga de la lista de salones, especialmente cuando hay muchas tarjetas.

Se añaden los estilos correspondientes a `SalonCard.css` para la nueva imagen.