### PR TITLE
Debug: Añade logs exhaustivos para props setter de cupones

### DIFF
--- a/src/components/Paso4_DatosYResumen.jsx
+++ b/src/components/Paso4_DatosYResumen.jsx
@@ -27,9 +27,25 @@ function Paso4_DatosYResumen({
   setValidandoCupon,
   // setDesglosePrecio, // Para actualizar el desglose general
   // onSocioDataChange,
-}) {
-  console.log('[Paso4] Inicio componente. Props de Cupón:', { codigoCuponInput, setCodigoCuponInput, cuponAplicado, setCuponAplicado, errorCupon, setErrorCupon, validandoCupon, setValidandoCupon });
-  console.log('[Paso4] Props generales recibidas:', { salonSeleccionado, fechaSeleccionada, horaInicio, horaTermino, desglosePrecio });
+}) { // La desestructuración original se mantiene por ahora para el resto del componente
+
+  // Loguear las props de cupón accediéndolas desde el objeto 'props' si está disponible,
+  // o desde las variables desestructuradas si 'props' no se pasó explícitamente.
+  // Nota: Para que 'props' esté disponible aquí, la firma de la función debería ser 'function Paso4_DatosYResumen(props) {'
+  // Como la firma actual desestructura, usaremos las variables desestructuradas para el log,
+  // ya que 'props' como tal no estaría definido en este scope a menos que cambiemos la firma.
+  // El log anterior ya hacía esto, lo mantendremos y confiaremos en él.
+  console.log('[Paso4] Inicio componente. Props de Cupón (desestructuradas):', {
+    codigoCuponInput,
+    setCodigoCuponInput: typeof setCodigoCuponInput, // Loguear typeof para funciones
+    cuponAplicado,
+    setCuponAplicado: typeof setCuponAplicado,
+    errorCupon,
+    setErrorCupon: typeof setErrorCupon,
+    validandoCupon,
+    setValidandoCupon: typeof setValidandoCupon
+  });
+  console.log('[Paso4] Props generales recibidas (desestructuradas):', { salonSeleccionado, fechaSeleccionada, horaInicio, horaTermino, desglosePrecio });
 
   // Inicialización de estados intentando cargar desde localStorage si no hay datos de socio
   const [clienteNombre, setClienteNombre] = useState(() => {
@@ -114,7 +130,8 @@ function Paso4_DatosYResumen({
     console.log('[Paso4] Inicio handleAplicarCuponLocal.');
     console.log('[Paso4] typeof setCuponAplicado:', typeof setCuponAplicado);
     console.log('[Paso4] typeof setErrorCupon:', typeof setErrorCupon);
-    console.log('[Paso4] typeof setValidandoCupon:', typeof setValidandoCupon);
+    console.log('[Paso4] typeof setValidandoCupon:', typeof setValidandoCupon, setValidandoCupon); // Loguear el valor también
+    console.log('[Paso4] Props object:', props); // Loguear el objeto props completo
 
     if (!codigoCuponInput.trim()) return;
 

--- a/src/pages/BookingPage.jsx
+++ b/src/pages/BookingPage.jsx
@@ -221,6 +221,13 @@ function BookingPage() {
       case 3:
         return <Paso3_SeleccionHorario salonSeleccionado={salonSeleccionado} fechaSeleccionada={fechaSeleccionada} horaInicio={horaInicio} setHoraInicio={setHoraInicio} horaTermino={horaTermino} setHoraTermino={setHoraTermino} desglosePrecio={desglosePrecio} duracionCalculada={duracionCalculada} nextStep={nextStep} prevStep={prevStep} />;
       case 4:
+        // --- INICIO LOGS DE DEPURACIÓN EN BOOKINGPAGE ---
+        console.log('[BookingPage] renderStep case 4. Verificando setters ANTES de pasar a Paso4:');
+        console.log('[BookingPage] typeof setCodigoCuponInput:', typeof setCodigoCuponInput, setCodigoCuponInput);
+        console.log('[BookingPage] typeof setCuponAplicado:', typeof setCuponAplicado, setCuponAplicado);
+        console.log('[BookingPage] typeof setErrorCupon:', typeof setErrorCupon, setErrorCupon);
+        console.log('[BookingPage] typeof setValidandoCupon:', typeof setValidandoCupon, setValidandoCupon);
+        // --- FIN LOGS DE DEPURACIÓN EN BOOKINGPAGE ---
         return (
           <Paso4_DatosYResumen
             salonSeleccionado={salonSeleccionado}
@@ -251,6 +258,7 @@ function BookingPage() {
           />
         );
       default:
+        // El console.log anterior aquí era incorrecto, ya que este es el caso default.
         return <SalonList onSalonSelect={handleSelectSalon} esSocio={!!socioData} />;
     }
   };


### PR DESCRIPTION
Se añaden console.log en BookingPage.jsx, justo antes de pasar las props a Paso4_DatosYResumen.jsx, para verificar el tipo y valor de las funciones setter (setCuponAplicado, setErrorCupon, etc.).

En Paso4_DatosYResumen.jsx, se ajusta el log inicial para mostrar el typeof de estas props setter recibidas.

Estos logs tienen como objetivo principal diagnosticar la causa raíz del `ReferenceError: setCuponAplicado is not defined` que ocurre al cargar o interactuar con Paso4_DatosYResumen, determinando si las props de función se están pasando y recibiendo correctamente.