### PR TITLE
Fix: Mostrar subtotal neto correcto en Paso 3

### DIFF
--- a/src/components/Paso3_SeleccionHorario.jsx
+++ b/src/components/Paso3_SeleccionHorario.jsx
@@ -132,7 +132,7 @@ function Paso3_SeleccionHorario({
         <div className="resumen-horario">
           <p>Duración: <strong>{duracionCalculada} {duracionCalculada === 1 ? 'hora' : 'horas'}</strong></p>
           {/* Mostrar el desglose del precio */}
-          <p>Subtotal (Neto): <strong>${(desglosePrecio.neto || 0).toLocaleString('es-CL')}</strong></p>
+          <p>Subtotal (Neto): <strong>${(desglosePrecio.netoOriginal || 0).toLocaleString('es-CL')}</strong></p>
           <p>IVA (19%): <strong>${(desglosePrecio.iva || 0).toLocaleString('es-CL')}</strong></p>
           <p>Total Estimado: <strong>${(desglosePrecio.total || 0).toLocaleString('es-CL')}</strong></p>
         </div>


### PR DESCRIPTION
El componente Paso3_SeleccionHorario.jsx intentaba acceder a desglosePrecio.neto, pero el objeto desglosePrecio calculado en BookingPage.jsx usa la propiedad netoOriginal para el valor neto antes de cupones.

Este cambio actualiza Paso3_SeleccionHorario.jsx para usar desglosePrecio.netoOriginal, asegurando que el subtotal (neto) se muestre correctamente en el resumen del Paso 3.