### PR TITLE
fix: Corregir ReferenceError 'duracion is not defined' en BookingPage

### DIFF
--- a/src/pages/BookingPage.jsx
+++ b/src/pages/BookingPage.jsx
@@ -132,7 +132,7 @@ function BookingPage() {
           total: totalCalculado,
         };
         // console.log('[BookingPage] setDesglosePrecio con:', nuevoDesglose);
-        setDuracionCalculada(duracion);
+        setDuracionCalculada(duracionPorDia); // CORRECCIÓN AQUÍ
         setDesglosePrecio(nuevoDesglose);
 
       } else { // Duración inválida


### PR DESCRIPTION
Este commit soluciona un error de referencia que ocurría al seleccionar un horario después de haber elegido una fecha. El error se debía a que en el `useEffect` de `BookingPage.jsx` que calcula el desglose de precios y la duración, se estaba intentando usar una variable `duracion` que ya no existía después de una refactorización (había sido renombrada a `duracionPorDia`).

Se ha corregido la línea `setDuracionCalculada(duracion)` por `setDuracionCalculada(duracionPorDia)` para utilizar la variable correcta. Esto debería resolver el `ReferenceError` y permitir que el cálculo de la duración y el precio (para un solo día, por ahora) proceda correctamente.