### PR TITLE
debug: Add console logs for multi-discrete selection flow

### DIFF
--- a/src/components/CustomCalendar.jsx
+++ b/src/components/CustomCalendar.jsx
@@ -186,17 +186,29 @@ function CustomCalendar({
           tempDate.setDate(tempDate.getDate() + 1);
           while (isBefore(tempDate, date)) {
             const tempDateString = formatearFechaParaAPI(tempDate);
-            const dayOfWeek = tempDate.getDay();
-            let dayIsDisabled = tempDate < today || dayOfWeek === 0 || dayOfWeek === 6;
+            // const dayOfWeek = tempDate.getDay(); // No necesitamos dayOfWeek para esta validación específica.
 
-            if (!dayIsDisabled && Array.isArray(blockedDatesList) && blockedDatesList.includes(tempDateString)) {
-              dayIsDisabled = true;
+            // Un día intermedio en un rango es inválido SI Y SOLO SI:
+            // 1. Es una fecha pasada.
+            // 2. Está en la lista de blockedDatesList (bloqueado por admin).
+            // 3. Está completamente ocupado según disponibilidadMensual.
+            // NO consideramos si es fin de semana para la validez del *rango intermedio*.
+            let dayInMiddleIsInvalid = false;
+
+            if (tempDate < today) {
+              dayInMiddleIsInvalid = true;
             }
+
+            if (!dayInMiddleIsInvalid && Array.isArray(blockedDatesList) && blockedDatesList.includes(tempDateString)) {
+              dayInMiddleIsInvalid = true;
+            }
+
             const infoDia = disponibilidadMensual ? disponibilidadMensual[tempDateString] : null;
-            if (!dayIsDisabled && infoDia && infoDia.ocupados >= infoDia.totalBloques) {
-              dayIsDisabled = true;
+            if (!dayInMiddleIsInvalid && infoDia && infoDia.ocupados >= infoDia.totalBloques) {
+              dayInMiddleIsInvalid = true;
             }
-            if (dayIsDisabled) {
+
+            if (dayInMiddleIsInvalid) {
               rangeIsValid = false;
               break;
             }

--- a/src/components/Paso2_SeleccionFecha.jsx
+++ b/src/components/Paso2_SeleccionFecha.jsx
@@ -104,9 +104,15 @@ function Paso2_SeleccionFecha({ salonSeleccionado, rangoSeleccionado, setRangoSe
   }, [rangoSeleccionado?.startDate, mesCalendario]);
 
   const handleModeChange = (mode) => {
+    console.log('[Paso2] handleModeChange - Nuevo modo:', mode);
     setCurrentSelectionMode(mode);
-    setRangoSeleccionado(null); // Resetear selección al cambiar de modo
-    // TODO: Si se usa un estado separado para 'multiple-discrete', resetearlo también.
+    setRangoSeleccionado(null);
+    console.log('[Paso2] handleModeChange - rangoSeleccionado reseteado a null');
+  };
+
+  const handleCalendarSelectionChange = (newSelection) => {
+    console.log('[Paso2] handleCalendarSelectionChange - Recibido de CustomCalendar:', newSelection);
+    setRangoSeleccionado(newSelection);
   };
 
   return (
@@ -137,8 +143,8 @@ function Paso2_SeleccionFecha({ salonSeleccionado, rangoSeleccionado, setRangoSe
 
       <div className="calendario-wrapper">
         <CustomCalendar 
-          selection={rangoSeleccionado} // rangoSeleccionado ahora es { startDate, endDate, discreteDates }
-          onSelectionChange={setRangoSeleccionado} // setRangoSeleccionado recibe el objeto completo
+          selection={rangoSeleccionado}
+          onSelectionChange={handleCalendarSelectionChange} // Usar el nuevo manejador
           onMonthChange={setMesCalendario}
           disponibilidadMensual={disponibilidadMensual}
           formatearFechaParaAPI={formatearFechaParaAPI}
@@ -153,27 +159,26 @@ function Paso2_SeleccionFecha({ salonSeleccionado, rangoSeleccionado, setRangoSe
        (currentSelectionMode === 'multiple-discrete' && rangoSeleccionado?.discreteDates && rangoSeleccionado.discreteDates.length > 0) ? (
         <div className="fecha-seleccionada-info">
           {currentSelectionMode === 'single' && rangoSeleccionado?.startDate &&
-            `Fecha seleccionada: <strong>${rangoSeleccionado.startDate.toLocaleDateString('es-ES', { weekday: 'long', day: 'numeric', month: 'long' })}</strong>`
+            <p>Fecha seleccionada: <strong>{rangoSeleccionado.startDate.toLocaleDateString('es-ES', { weekday: 'long', day: 'numeric', month: 'long' })}</strong></p>
           }
           {currentSelectionMode === 'range' && rangoSeleccionado?.startDate && rangoSeleccionado?.endDate && !isSameDay(rangoSeleccionado.startDate, rangoSeleccionado.endDate) &&
-            <>
-              Fecha de inicio: <strong>{rangoSeleccionado.startDate.toLocaleDateString('es-ES', { weekday: 'long', day: 'numeric', month: 'long' })}</strong>
-              <br />
-              Fecha de fin: <strong>{rangoSeleccionado.endDate.toLocaleDateString('es-ES', { weekday: 'long', day: 'numeric', month: 'long' })}</strong>
-            </>
+            <div>
+              <p>Fecha de inicio: <strong>{rangoSeleccionado.startDate.toLocaleDateString('es-ES', { weekday: 'long', day: 'numeric', month: 'long' })}</strong></p>
+              <p>Fecha de fin: <strong>{rangoSeleccionado.endDate.toLocaleDateString('es-ES', { weekday: 'long', day: 'numeric', month: 'long' })}</strong></p>
+            </div>
           }
           {currentSelectionMode === 'range' && rangoSeleccionado?.startDate && (!rangoSeleccionado?.endDate || isSameDay(rangoSeleccionado.startDate, rangoSeleccionado.endDate)) &&
-            `Día de inicio seleccionado: <strong>${rangoSeleccionado.startDate.toLocaleDateString('es-ES', { weekday: 'long', day: 'numeric', month: 'long' })}</strong> (Seleccione día de fin)`
+            <p>Día de inicio seleccionado: <strong>{rangoSeleccionado.startDate.toLocaleDateString('es-ES', { weekday: 'long', day: 'numeric', month: 'long' })}</strong> (Seleccione día de fin)</p>
           }
           {currentSelectionMode === 'multiple-discrete' && rangoSeleccionado?.discreteDates && rangoSeleccionado.discreteDates.length > 0 &&
-            <>
-              Días seleccionados:
+            <div>
+              <p>Días seleccionados:</p>
               <ul>
                 {rangoSeleccionado.discreteDates.map(date => (
                   <li key={date.toISOString()}><strong>{date.toLocaleDateString('es-ES', { weekday: 'short', day: 'numeric', month: 'short' })}</strong></li>
                 ))}
               </ul>
-            </>
+            </div>
           }
         </div>
       ) : null}

--- a/src/components/Paso3_SeleccionHorario.jsx
+++ b/src/components/Paso3_SeleccionHorario.jsx
@@ -32,8 +32,10 @@ function Paso3_SeleccionHorario({
   const BUFFER_SLOTS = 1;
 
   useEffect(() => {
+    console.log('[Paso3] useEffect - Props recibidas: currentSelectionMode:', currentSelectionMode, 'rangoSeleccionado:', rangoSeleccionado);
+
     let fechasAProcesar = [];
-    let esMultiplesDias = false; // Para el mensaje al usuario
+    let esMultiplesDias = false;
 
     if (salonSeleccionado && rangoSeleccionado) {
       if (currentSelectionMode === 'single' && rangoSeleccionado.startDate) {
@@ -44,18 +46,22 @@ function Paso3_SeleccionHorario({
           fechasAProcesar = eachDayOfInterval({ start: rangoSeleccionado.startDate, end: rangoSeleccionado.endDate });
           esMultiplesDias = fechasAProcesar.length > 1;
         } else if (isSameDay(rangoSeleccionado.startDate, rangoSeleccionado.endDate)) {
-          // Considerar rango de un solo día como 'single' en términos de procesamiento aquí
           fechasAProcesar = [rangoSeleccionado.startDate];
           esMultiplesDias = false;
         } else {
-          console.warn("Paso3: En modo rango, fecha de fin es anterior a fecha de inicio.");
-          fechasAProcesar = []; // No procesar si el rango es inválido
+          console.warn("[Paso3] En modo rango, fecha de fin es anterior a fecha de inicio.");
+          fechasAProcesar = [];
         }
-      } else if (currentSelectionMode === 'multiple-discrete' && rangoSeleccionado.discreteDates && rangoSeleccionado.discreteDates.length > 0) {
-        fechasAProcesar = [...rangoSeleccionado.discreteDates].sort((a,b) => a - b); // Usar copia ordenada
+      } else if (currentSelectionMode === 'multiple-discrete' && rangoSeleccionado.discreteDates && Array.isArray(rangoSeleccionado.discreteDates) && rangoSeleccionado.discreteDates.length > 0) {
+        fechasAProcesar = [...rangoSeleccionado.discreteDates].sort((a,b) => a - b);
         esMultiplesDias = fechasAProcesar.length > 1;
+      } else if (currentSelectionMode === 'multiple-discrete' && (!rangoSeleccionado.discreteDates || rangoSeleccionado.discreteDates.length === 0)) {
+        console.log('[Paso3] Modo multiple-discrete pero discreteDates está vacío o no es un array.');
+        fechasAProcesar = [];
       }
     }
+
+    console.log('[Paso3] Fechas a procesar:', fechasAProcesar);
 
     if (salonSeleccionado && fechasAProcesar.length > 0) {
       const fetchDisponibilidadParaFechas = async () => {


### PR DESCRIPTION
Added console.log statements in Paso2_SeleccionFecha.jsx and Paso3_SeleccionHorario.jsx to trace the state of currentSelectionMode and rangoSeleccionado (specifically discreteDates) when using the 'Varios días (no consecutivos)' selection mode.

This is to help diagnose an issue where available slots are not being displayed correctly in Paso3 for this mode.

Includes previous fixes:
- Corrected rendering of <strong> tags in Paso2_SeleccionFecha.
- Allowed range selection in CustomCalendar to span across weekends (weekends are no longer intermediate blockers for range validity).