### PR TITLE
fix: Ensure correct currentSelectionMode propagation for multi-discre…

### DIFF
--- a/src/components/Paso2_SeleccionFecha.jsx
+++ b/src/components/Paso2_SeleccionFecha.jsx
@@ -4,13 +4,21 @@ import CustomCalendar from './CustomCalendar';
 import './Paso2_SeleccionFecha.css';
 import { parse as parseDate, format as formatDate, parseISO, isSameDay } from 'date-fns'; // Añadir isSameDay
 
-function Paso2_SeleccionFecha({ salonSeleccionado, rangoSeleccionado, setRangoSeleccionado, nextStep, prevStep }) {
+function Paso2_SeleccionFecha({
+  salonSeleccionado,
+  rangoSeleccionado,
+  setRangoSeleccionado,
+  currentSelectionMode, // Recibir como prop
+  setCurrentSelectionMode, // Recibir como prop
+  nextStep,
+  prevStep
+}) {
   const [disponibilidadMensual, setDisponibilidadMensual] = useState({});
   const [blockedDates, setBlockedDates] = useState([]); // Estado para fechas bloqueadas
-  // mesCalendario se basará en startDate del rango, o la fecha actual si no hay startDate
   const [mesCalendario, setMesCalendario] = useState(rangoSeleccionado?.startDate || new Date());
   const [isLoadingBlockedDates, setIsLoadingBlockedDates] = useState(false);
-  const [currentSelectionMode, setCurrentSelectionMode] = useState('single'); // 'single', 'range', 'multiple-discrete'
+  // EL ESTADO LOCAL currentSelectionMode SE ELIMINA. Se usarán las props.
+  // const [currentSelectionMode, setCurrentSelectionMode] = useState('single');
 
   const formatearFechaParaAPI = (date) => date ? formatDate(date, 'yyyy-MM-dd') : '';
 


### PR DESCRIPTION
…te flow

This commit addresses an issue where `Paso3_SeleccionHorario` was receiving an incorrect `currentSelectionMode` when 'Varios días no consecutivos' was selected in `Paso2_SeleccionFecha`.

The root cause was that `Paso2_SeleccionFecha` was using a local state for `currentSelectionMode` instead of the prop passed down from `BookingPage.jsx`. This prevented the mode change from being communicated hidrógeno to the parent and then to `Paso3_SeleccionHorario`.

Correction:
- Removed the local `currentSelectionMode` state from `Paso2_SeleccionFecha.jsx`.
- Ensured `Paso2_SeleccionFecha` now uses the `currentSelectionMode` and `setCurrentSelectionMode` props provided by `BookingPage.jsx`.

This change should allow `Paso3_SeleccionHorario` to correctly interpret the `rangoSeleccionado.discreteDates` based on the accurate `currentSelectionMode`, and subsequently display available common horarios for multiple discrete dates.

Debug console.log statements remain in place for further testing of this flow.