### PR TITLE
feat: Implementar cálculo de precios y resumen para múltiples días

### DIFF
--- a/src/pages/BookingPage.jsx
+++ b/src/pages/BookingPage.jsx
@@ -93,8 +93,7 @@ function BookingPage() {
         const precioNetoHora = getPrecioNetoPorHora(salonSeleccionado, !!socioData);
 
         // El neto original es por la duración total de todos los días.
-        // TEMPORALMENTE: Se calcula como si fuera un solo día hasta que se implemente bien el desglose multi-día
-        const netoOriginalCalculadoParaCupon = duracionPorDia * precioNetoHora; // * numDias; // <-- Multiplicar por numDias cuando se ajuste el desglose
+        const netoOriginalCalculadoParaCupon = duracionPorDia * precioNetoHora * numDias;
 
         let netoFinalTrasCupon = netoOriginalCalculadoParaCupon;
         let montoDescuentoCuponActual = 0;
@@ -144,7 +143,8 @@ function BookingPage() {
       setDuracionCalculada(0);
       setDesglosePrecio({ netoOriginal: 0, montoDescuentoCupon: 0, netoConDescuento: 0, iva: 0, total: 0 });
     }
-  }, [salonSeleccionado, horaInicio, horaTermino, socioData, cuponAplicado, setCuponAplicado, setErrorCupon]);
+  }, [salonSeleccionado, horaInicio, horaTermino, socioData, cuponAplicado, rangoSeleccionado, currentSelectionMode, setCuponAplicado, setErrorCupon]);
+  // Añadidas rangoSeleccionado y currentSelectionMode a las dependencias
   
   const handleValidationSuccess = (datosSocio) => {
     setSocioData(datosSocio);
@@ -264,8 +264,9 @@ function BookingPage() {
         return (
           <Paso4_DatosYResumen
             salonSeleccionado={salonSeleccionado}
-            fechaSeleccionada={rangoSeleccionado?.startDate} // Temporal: Pasar solo startDate como 'fechaSeleccionada'
-            // Se necesitará pasar rangoSeleccionado y currentSelectionMode a Paso4 para lógica de múltiples días
+            rangoSeleccionado={rangoSeleccionado} // Pasar el objeto completo
+            currentSelectionMode={currentSelectionMode} // Pasar el modo
+            numDias={numDias} // Pasar el número de días calculado
             horaInicio={horaInicio}
             horaTermino={horaTermino}
             desglosePrecio={desglosePrecio}


### PR DESCRIPTION
Este commit actualiza la lógica de cálculo de precios y la visualización del resumen para manejar correctamente las reservas que abarcan múltiples días, ya sea como un rango continuo o como una selección de días no consecutivos.

Cambios Principales:

1.  **`BookingPage.jsx`:**
    *   El `useEffect` que calcula `desglosePrecio` ahora utiliza la
        variable `numDias` (determinada a partir de `rangoSeleccionado` y
        `currentSelectionMode`) para calcular el `netoOriginalCalculadoParaCupon`,
        asegurando que el precio base refleje la duración total en todos
        los días seleccionados.
    *   Se pasan las props `numDias`, `rangoSeleccionado` (completo), y
        `currentSelectionMode` a `Paso4_DatosYResumen.jsx`.

2.  **`Paso4_DatosYResumen.jsx`:**
    *   Recibe y utiliza las nuevas props para mostrar un resumen de reserva
        más detallado y preciso según el modo de selección:
        *   Muestra "Fecha" para día único.
        *   Muestra "Desde" y "Hasta" para rangos.
        *   Lista los "Días seleccionados" para el modo múltiple-discreto.
        *   La duración se presenta como "X horas por día" y "Número de días: Y"
          cuando aplica.
    *   La función `handleSubmit` ahora construye el objeto `datosReserva`
        para el backend incluyendo `fecha_fin_reserva` (para rangos) o
        `dias_discretos` (para selección múltiple) según el
        `currentSelectionMode`.

Estos cambios aseguran que el precio refleje la selección de múltiples días y que el usuario vea un resumen coherente antes de confirmar. Se requieren pruebas manuales y adaptaciones correspondientes en el backend.