### PR TITLE
fix: Adaptar BlockedDatesManager al nuevo CustomCalendar

### DIFF
--- a/src/components/BlockedDatesManager.jsx
+++ b/src/components/BlockedDatesManager.jsx
@@ -35,8 +35,15 @@ function BlockedDatesManager() {
 
   const formatearFechaParaAPI = (date) => date ? formatDate(date, 'yyyy-MM-dd') : '';
 
-  const handleDateSelect = (date) => {
-    setSelectedDate(date);
+  // Nueva función para manejar el objeto de selección del CustomCalendar
+  const handleCalendarSelection = (selectionObject) => {
+    // Para bloquear días, solo nos interesa startDate, y como el modo será 'single',
+    // startDate y endDate serán la misma.
+    if (selectionObject && selectionObject.startDate) {
+      setSelectedDate(selectionObject.startDate);
+    } else {
+      setSelectedDate(null); // Si por alguna razón no hay startDate (ej. al deseleccionar)
+    }
   };
 
   const handleBlockDate = async () => {
@@ -96,16 +103,14 @@ function BlockedDatesManager() {
       <div className="block-date-form">
         <div className="calendar-section">
           <CustomCalendar
-            selectedDate={selectedDate}
-            onDateSelect={handleDateSelect}
-            onMonthChange={setCalendarMonth} // Para que el calendario pueda cambiar de mes
-            // Pasaremos las fechas bloqueadas para que el calendario pueda, opcionalmente, marcarlas.
-            // Necesitaremos modificar CustomCalendar para usar esta prop.
+            // Para modo 'single', selection espera { startDate, endDate } donde ambos son la misma fecha
+            selection={selectedDate ? { startDate: selectedDate, endDate: selectedDate, discreteDates: [] } : null}
+            onSelectionChange={handleCalendarSelection}
+            onMonthChange={setCalendarMonth}
             blockedDatesList={blockedDates.map(bd => bd.date)}
             formatearFechaParaAPI={formatearFechaParaAPI}
-            // Pasamos una disponibilidad mensual vacía o nula ya que este calendario
-            // no se usa para mostrar ocupación, solo para seleccionar fechas.
-            disponibilidadMensual={{}}
+            disponibilidadMensual={{}} // No se usa para mostrar ocupación, solo para seleccionar
+            selectionMode='single' // Especificar el modo de selección
           />
         </div>
         <div className="form-section">


### PR DESCRIPTION
Este commit corrige un error 'TypeError: t is not a function' que ocurría en el componente `BlockedDatesManager` al interactuar con el calendario.

El error se debía a que `BlockedDatesManager` no se había actualizado para usar la nueva interfaz de props de `CustomCalendar` (que ahora maneja múltiples modos de selección y espera `selection` y `onSelectionChange` en lugar de `selectedDate` y `onDateSelect`).

Cambios en `BlockedDatesManager.jsx`:
- Se actualizó la función de callback que maneja la selección de fecha para que acepte el objeto `selection` de `CustomCalendar` y extraiga `startDate`.
- Se modificaron las props pasadas a `<CustomCalendar />`:
  - `selection` ahora se construye como `{ startDate, endDate }` (ambas iguales a la fecha seleccionada).
  - Se usa `onSelectionChange` en lugar de `onDateSelect`.
  - Se especifica `selectionMode='single'`.

Estos cambios aseguran que `BlockedDatesManager` se integre correctamente con la versión actualizada de `CustomCalendar`.