### PR TITLE
style: Mejorar estilo y feedback de botones de selección de modo

### DIFF
--- a/src/components/Paso2_SeleccionFecha.css
+++ b/src/components/Paso2_SeleccionFecha.css
@@ -20,24 +20,28 @@
 }
 
 .modo-seleccion-container button {
-  padding: 8px 15px;
-  border: 1px solid var(--color-indigo-300);
-  background-color: var(--color-white);
+  padding: 10px 18px; /* Aumentar padding para mejor apariencia */
+  border: 1px solid var(--color-indigo-500); /* Borde más oscuro para inactivos */
+  background-color: transparent; /* Fondo transparente para inactivos */
   color: var(--color-indigo-600);
-  border-radius: var(--border-radius-md);
+  border-radius: var(--border-radius-lg); /* Más redondeado */
   cursor: pointer;
-  transition: background-color 0.2s, color 0.2s;
-  font-size: 0.9em;
+  transition: background-color 0.2s ease-in-out, color 0.2s ease-in-out, border-color 0.2s ease-in-out;
+  font-size: 0.95em; /* Ligeramente más grande */
+  font-weight: 500; /* Un poco más de peso */
+  line-height: 1; /* Para asegurar que el texto no cause saltos de altura */
 }
 
-.modo-seleccion-container button:hover:not(:disabled) {
+.modo-seleccion-container button:hover:not(:disabled):not(.active) { /* Hover solo para inactivos */
   background-color: var(--color-indigo-50);
+  border-color: var(--color-indigo-600); /* Borde más oscuro en hover */
 }
 
 .modo-seleccion-container button.active {
   background-color: var(--color-indigo-600);
   color: var(--color-white);
-  border-color: var(--color-indigo-600);
+  border-color: var(--color-indigo-600); /* Asegurar que el borde coincida */
+  font-weight: 600; /* Más peso para el activo */
 }
 
 .modo-seleccion-container button:disabled {


### PR DESCRIPTION
Este commit actualiza los estilos CSS para los botones de selección de modo ('Un solo día', 'Rango de días', 'Varios días no consecutivos') en el Paso 2 del flujo de reserva (`Paso2_SeleccionFecha.css`).

Cambios:
- Los botones inactivos ahora tienen un fondo transparente, un borde del color primario (índigo), y texto en color primario.
- Se aumentó el padding y el border-radius para una apariencia más refinada y consistente con otros elementos de la UI.
- El estado hover para botones inactivos ahora tiene un ligero fondo y un borde más oscuro para mejor feedback.
- El estado activo (.active) mantiene su estilo distintivo (fondo índigo, texto blanco) y se le dio un mayor peso de fuente.
- Se mejoraron las transiciones para suavidad.

Estos cambios buscan mejorar la integración visual de los botones con el diseño general de la página y proporcionar una indicación más clara del modo de selección de fecha que está actualmente activo.