### PR TITLE
debug: Add console log for reservation payload and instruct user

### DIFF
--- a/src/components/Paso4_DatosYResumen.jsx
+++ b/src/components/Paso4_DatosYResumen.jsx
@@ -308,7 +308,9 @@ function Paso4_DatosYResumen(props) {
     }
 
     // Se podría dejar este log si aún se está depurando la interacción con el backend.
-    console.log('[Paso4] Enviando a /reservas FINAL:', datosReserva);
+    // console.log('[Paso4] Enviando a /reservas FINAL:', datosReserva); // Comentado el log anterior
+    console.log('[DEBUG Frontend] Enviando al backend /api/reservas:', JSON.stringify(datosReserva, null, 2));
+
 
     try {
       const responseReserva = await api.post('/reservas', datosReserva);


### PR DESCRIPTION
Añadido un console.log en `Paso4_DatosYResumen.jsx` para mostrar el objeto `datosReserva` exacto que se envía al backend al intentar crear una reserva.

Esto ayudará a depurar el error "Error al procesar la reserva. No se obtuvo ID." al permitirnos comparar el payload enviado con la respuesta recibida del backend (que el usuario deberá obtener de la pestaña Network).