### PR TITLE
fix: Adaptar manejo de respuesta de creación de reserva

### DIFF
--- a/src/components/Paso4_DatosYResumen.jsx
+++ b/src/components/Paso4_DatosYResumen.jsx
@@ -314,10 +314,14 @@ function Paso4_DatosYResumen(props) {
 
     try {
       const responseReserva = await api.post('/reservas', datosReserva);
-      const backendResponse = responseReserva.data; // Renamed for clarity
-      const reservaData = backendResponse.reserva; // Access the nested 'reserva' object
+      const backendResponse = responseReserva.data;
 
-      if (reservaData && reservaData.id) { // Check for reservaData and reservaData.id
+      // Adaptar a la estructura de respuesta del backend: un array 'reservas'
+      const reservaPrincipal = backendResponse.reservas && backendResponse.reservas.length > 0
+        ? backendResponse.reservas[0]
+        : null;
+
+      if (reservaPrincipal && reservaPrincipal.id) {
         // setMensajeReserva({ texto: 'Solicitud de reserva recibida. Redirigiendo al portal de pagos...', tipo: 'info' });
 
         // --- Inicio: Modificación para manejo temporal sin pasarela de pago ---
@@ -329,7 +333,7 @@ function Paso4_DatosYResumen(props) {
         // Comentado: Bloque de inicio de pago
         // // Iniciar el proceso de pago
         // try {
-        //   const responseInicioPago = await api.post(`/reservas/${reservaData.id}/iniciar-pago`); // Use reservaData.id
+        //   const responseInicioPago = await api.post(`/reservas/${reservaPrincipal.id}/iniciar-pago`); // Use reservaPrincipal.id
         //   if (responseInicioPago.data && responseInicioPago.data.url_pago) {
         //     window.location.href = responseInicioPago.data.url_pago;
         //     // No llamar a onReservationSuccess aquí, la redirección se encarga.


### PR DESCRIPTION
Este commit ajusta `Paso4_DatosYResumen.jsx` para interpretar correctamente la estructura de la respuesta del backend al crear una reserva.

Anteriormente, el frontend esperaba que los datos de la reserva estuvieran en `response.data.reserva`. Sin embargo, el backend devuelve un array `response.data.reservas`, donde la información de la reserva creada (para rangos o días únicos) se encuentra en el primer elemento de este array.

Cambios:
- Se modificó la lógica en `handleSubmit` para acceder a `backendResponse.reservas[0]` en lugar de `backendResponse.reserva` para obtener los datos y el ID de la reserva principal.

Esto debería resolver el error "Error al procesar la reserva. No se obtuvo ID." si el backend crea la reserva exitosamente y devuelve el ID en la estructura de array mencionada.

Nota: El problema del cálculo incorrecto del precio en los correos (que solo considera un día) sigue siendo un asunto pendiente del backend, ya que el frontend envía el costo_total correcto para el período completo.