### PR TITLE
refactor: Renombrar campo de precio en payload de reserva

### DIFF
--- a/src/components/Paso4_DatosYResumen.jsx
+++ b/src/components/Paso4_DatosYResumen.jsx
@@ -279,7 +279,8 @@ function Paso4_DatosYResumen(props) {
 
     datosReserva.hora_inicio = horaInicio;
     datosReserva.hora_termino = horaTermino;
-    datosReserva.costo_total = desglosePrecio?.total; // Esto ya está calculado con numDias en BookingPage
+    // datosReserva.costo_total = desglosePrecio?.total; // Nombre anterior
+    datosReserva.precio_total_enviado_cliente = desglosePrecio?.total; // Nuevo nombre del campo
 
     datosReserva.notas_adicionales = notasAdicionales;
     datosReserva.tipo_documento = tipoDocumento;


### PR DESCRIPTION
Se ha cambiado el nombre del campo que envía el precio total calculado por el frontend al backend en el momento de la creación de la reserva.

Anteriormente: `costo_total`
Nuevo nombre: `precio_total_enviado_cliente`

Este cambio se realizó en `Paso4_DatosYResumen.jsx` dentro de la función `handleSubmit` al construir el objeto `datosReserva`.

El backend deberá ser actualizado para esperar este nuevo nombre de campo.