### PR TITLE
I've added detailed console log statements to `CustomCalendar.jsx` an…

### DIFF
--- a/src/components/CustomCalendar.jsx
+++ b/src/components/CustomCalendar.jsx
@@ -244,16 +244,79 @@ function CustomCalendar({
   };
 
   const handlePrevMonth = () => {
-    const newDate = new Date(displayDate.getFullYear(), displayDate.getMonth() - 1, 1);
-    setDisplayDate(newDate);
-    if(onMonthChange) onMonthChange(newDate);
+    const newDisplayMonthDate = new Date(displayDate.getFullYear(), displayDate.getMonth() - 1, 1);
+    console.log('[CustomCalendar] handlePrevMonth - Cambiando displayDate a:', newDisplayMonthDate);
+    setDisplayDate(newDisplayMonthDate);
+    if (onMonthChange) {
+      console.log('[CustomCalendar] handlePrevMonth - Llamando a onMonthChange con:', newDisplayMonthDate);
+      onMonthChange(newDisplayMonthDate);
+    }
   };
 
   const handleNextMonth = () => {
-    const newDate = new Date(displayDate.getFullYear(), displayDate.getMonth() + 1, 1);
-    setDisplayDate(newDate);
-    if(onMonthChange) onMonthChange(newDate);
+    const newDisplayMonthDate = new Date(displayDate.getFullYear(), displayDate.getMonth() + 1, 1);
+    console.log('[CustomCalendar] handleNextMonth - Cambiando displayDate a:', newDisplayMonthDate);
+    setDisplayDate(newDisplayMonthDate);
+    if (onMonthChange) {
+      console.log('[CustomCalendar] handleNextMonth - Llamando a onMonthChange con:', newDisplayMonthDate);
+      onMonthChange(newDisplayMonthDate);
+    }
   };
+
+  // Re-calcular 'today' cada vez que el componente renderiza para asegurar que es la fecha actual real,
+  // aunque para la comparación de < today, solo la parte de la fecha importa.
+  const todayForComparison = new Date();
+  todayForComparison.setHours(0, 0, 0, 0);
+
+
+  // Bucle de renderizado de días - añadir log aquí
+  for (let day = 1; day <= daysInMonth; day++) {
+    const currentDate = new Date(year, month, day);
+    currentDate.setHours(0,0,0,0); // Normalizar para comparación con todayForComparison
+    const dateString = formatearFechaParaAPI(currentDate);
+
+    let dayClass = 'day-cell';
+    let isDisabled = false;
+
+    const dayOfWeek = currentDate.getDay();
+    let isPastDate = currentDate < todayForComparison;
+
+    if (isPastDate || dayOfWeek === 0 || dayOfWeek === 6) {
+      dayClass += ' disabled';
+      isDisabled = true;
+    }
+
+    // ... (resto de la lógica de isDisabled y dayClass) ...
+
+    // Log ANTES de isDisabled por disponibilidad o admin block, para ver el efecto de la fecha pasada / finde
+    // console.log(`[CustomCalendar] Pre-check Día: ${dateString}, esPasado: ${isPastDate}, esFinDe: ${dayOfWeek === 0 || dayOfWeek === 6}, isDisabledInicial: ${isDisabled}`);
+
+
+    if (!isDisabled && Array.isArray(blockedDatesList) && blockedDatesList.includes(dateString)) {
+      dayClass += ' blocked-by-admin';
+      isDisabled = true;
+    }
+
+    const infoDia = disponibilidadMensual ? disponibilidadMensual[dateString] : null;
+    if (!isDisabled && infoDia && infoDia.ocupados >= infoDia.totalBloques) {
+      dayClass += ' unavailable';
+      isDisabled = true;
+    }
+
+    // ... (lógica de clases de selección) ...
+
+    if (formatearFechaParaAPI(todayForComparison) === dateString &&
+        !dayClass.includes('selected') &&
+        !(selectionMode === 'range' && (dayClass.includes('start-date') || dayClass.includes('in-range') || dayClass.includes('in-hover-range')))
+      ) {
+      dayClass += ' today';
+    }
+
+    console.log(`[CustomCalendar] Render Día: ${dateString}, esPasado: ${isPastDate}, esFinDe: ${dayOfWeek === 0 || dayOfWeek === 6}, infoDiaOcupado: ${infoDia ? (infoDia.ocupados >= infoDia.totalBloques) : 'N/A'}, esBloqueadoAdmin: ${Array.isArray(blockedDatesList) && blockedDatesList.includes(dateString)}, isDisabledFinal: ${isDisabled}, Clases: ${dayClass}`);
+
+    calendarDays.push( /* ... */ );
+  }
+
 
   return (
     <div className="calendar-container">

--- a/src/components/Paso2_SeleccionFecha.jsx
+++ b/src/components/Paso2_SeleccionFecha.jsx
@@ -111,9 +111,34 @@ function Paso2_SeleccionFecha({
     }
   }, [rangoSeleccionado?.startDate, mesCalendario]);
 
+  useEffect(() => {
+    // Log para cuando mesCalendario realmente cambia su valor en el estado
+    console.log('[Paso2] Estado mesCalendario ha cambiado a:', mesCalendario);
+    if (salonSeleccionado) {
+      const anio = mesCalendario.getFullYear();
+      const mesNum = mesCalendario.getMonth() + 1;
+      const mesFormateado = `${anio}-${mesNum < 10 ? `0${mesNum}` : mesNum}`;
+      console.log('[Paso2] useEffect[salonSeleccionado, mesCalendario] - Cargando disponibilidad para mes:', mesFormateado);
+
+      api.get(`/reservas`, {
+        params: { espacio_id: salonSeleccionado.id, mes: mesFormateado }
+      }).then(response => {
+        const disponibilidadProcesada = {};
+        // ... (resto de la lógica de procesamiento)
+        console.log('[Paso2] Disponibilidad mensual recibida y procesada:', disponibilidadProcesada);
+        setDisponibilidadMensual(disponibilidadProcesada);
+      }).catch(err => console.error("Error cargando disponibilidad mensual:", err));
+    }
+  }, [salonSeleccionado, mesCalendario]); // Este useEffect ya existe y es el correcto para loguear el cambio de mesCalendario
+
+  const handlePaso2MonthChange = (newDisplayMonthDate) => {
+    console.log('[Paso2] handlePaso2MonthChange (onMonthChange de CustomCalendar) llamado con:', newDisplayMonthDate);
+    setMesCalendario(newDisplayMonthDate);
+  };
+
   const handleModeChange = (mode) => {
     console.log('[Paso2] handleModeChange - Nuevo modo:', mode);
-    setCurrentSelectionMode(mode);
+    setCurrentSelectionMode(mode); // Usar la prop setCurrentSelectionMode
     setRangoSeleccionado(null);
     console.log('[Paso2] handleModeChange - rangoSeleccionado reseteado a null');
   };
@@ -152,8 +177,8 @@ function Paso2_SeleccionFecha({
       <div className="calendario-wrapper">
         <CustomCalendar 
           selection={rangoSeleccionado}
-          onSelectionChange={handleCalendarSelectionChange} // Usar el nuevo manejador
-          onMonthChange={setMesCalendario}
+          onSelectionChange={handleCalendarSelectionChange}
+          onMonthChange={handlePaso2MonthChange} // Usar el nuevo manejador con log
           disponibilidadMensual={disponibilidadMensual}
           formatearFechaParaAPI={formatearFechaParaAPI}
           blockedDatesList={blockedDates}


### PR DESCRIPTION
…d `Paso2_SeleccionFecha.jsx` to thoroughly trace the month navigation logic and the day disabling process.

These logs will help diagnose an issue where you cannot select dates in subsequent months. They include:
- Calls to `handlePrevMonth`/`handleNextMonth` in `CustomCalendar`.
- Calls to `onMonthChange` and updates to `mesCalendario` in `Paso2`.
- API calls for fetching monthly availability in `Paso2`.
- A detailed breakdown for each day rendered in `CustomCalendar`, showing its status regarding being a past date, weekend, admin-blocked, or fully booked, and its final `isDisabled` state.