### PR TITLE
Style: Redondeados los bordes de los botones de selección de modo

### DIFF
--- a/src/components/Paso2_SeleccionFecha.css
+++ b/src/components/Paso2_SeleccionFecha.css
@@ -24,7 +24,7 @@
   border: 1px solid var(--color-indigo-500); /* Borde más oscuro para inactivos */
   background-color: transparent; /* Fondo transparente para inactivos */
   color: var(--color-indigo-600);
-  border-radius: var(--border-radius-lg); /* Más redondeado */
+  border-radius: 20px; /* Bordes más redondeados tipo píldora */
   cursor: pointer;
   transition: background-color 0.2s ease-in-out, color 0.2s ease-in-out, border-color 0.2s ease-in-out;
   font-size: 0.95em; /* Ligeramente más grande */


### PR DESCRIPTION
Se actualizó el estilo de los botones de selección de modo ('Un solo día', 'Rango de días', 'Varios días') en el Paso 2 de la página de reservas para que tengan bordes más redondeados (20px), dándoles una apariencia de píldora y mejorando la consistencia visual con otros elementos de la interfaz.