### PR TITLE
Fix: Restaurados los colores para los estados de reserva en el panel …

### DIFF
--- a/src/components/ReservasManager.css
+++ b/src/components/ReservasManager.css
@@ -10,3 +10,46 @@
   /* Podrías añadir estilos aquí si usas un tooltip personalizado,
      o si quieres que el texto se expanda al hacer hover (aunque puede ser complicado con text-overflow) */
 }
+
+/* Estilos para los badges de estado de reserva */
+.status-badge {
+  padding: 0.25em 0.6em; /* Ajusta el padding según sea necesario */
+  border-radius: var(--border-radius-xl, 0.75rem); /* Usa la variable global o un fallback */
+  font-size: 0.85em;
+  font-weight: 600;
+  text-transform: capitalize;
+  line-height: 1;
+  white-space: nowrap;
+  display: inline-block; /* Para que el padding y otros estilos se apliquen correctamente */
+}
+
+.status-pendiente {
+  background-color: #fffbeb; /* Amarillo muy claro (similar a bg-yellow-50) */
+  color: #b45309; /* Amarillo oscuro (similar a text-yellow-700) */
+  border: 1px solid #fde68a; /* Amarillo claro (similar a border-yellow-300) */
+}
+
+.status-confirmada {
+  background-color: var(--color-green-50, #f0fdf4); /* Verde muy claro (usando color-green-50 si existe, o fallback) */
+  color: var(--color-green-700, #047857); /* Verde oscuro */
+  border: 1px solid var(--color-green-300, #86efac); /* Verde claro */
+}
+
+.status-pagado {
+  background-color: var(--color-blue-50, #eff6ff); /* Azul muy claro */
+  color: var(--color-blue-700, #1d4ed8); /* Azul oscuro */
+  border: 1px solid var(--color-blue-300, #93c5fd); /* Azul claro */
+}
+
+.status-cancelada_por_admin,
+.status-cancelada { /* Clase genérica por si se usa "cancelada" */
+  background-color: var(--color-red-100, #fee2e2); /* Rojo muy claro */
+  color: var(--color-red-700, #b91c1c); /* Rojo oscuro */
+  border: 1px solid var(--color-red-300, #fca5a5); /* Rojo claro */
+}
+
+.status-cancelada_por_cliente {
+  background-color: var(--color-gray-100, #f3f4f6); /* Gris muy claro */
+  color: var(--color-gray-600, #4b5563); /* Gris oscuro */
+  border: 1px solid var(--color-gray-300, #d1d5db); /* Gris claro */
+}


### PR DESCRIPTION
…de admin

Añadí estilos CSS al archivo `ReservasManager.css` para restaurar la indicación visual de los diferentes estados de reserva (Pendiente, Confirmada, Pagado, Cancelada) en la tabla de gestión de reservas del panel de administración.

Ahora cada estado de reserva se muestra con un color de fondo y texto distintivo, mejorando la legibilidad y la rápida identificación del estado de cada reserva.