### PR TITLE
Feat: Añadir reserva a calendario con menú de opciones (.ics y Google)

### DIFF
--- a/src/components/Paso4_DatosYResumen.css
+++ b/src/components/Paso4_DatosYResumen.css
@@ -263,3 +263,61 @@
 .resumen-fila.subtotal-descuento strong {
   font-weight: 700; /* Destacar el subtotal con descuento */
 }
+
+/* Estilos para el botón y menú de "Añadir a Calendario" */
+.accion-post-reserva {
+  margin-top: 20px;
+  text-align: center; /* Centra el botón principal */
+  position: relative; /* Para el posicionamiento absoluto del menú */
+}
+
+.boton-principal-calendario {
+  background-color: var(--color-indigo-600);
+  color: var(--color-white);
+  padding: 10px 20px;
+  border-radius: 8px;
+  border: none;
+  cursor: pointer;
+  font-weight: 600;
+  font-size: 1em;
+  transition: background-color 0.2s ease;
+}
+.boton-principal-calendario:hover {
+  background-color: var(--color-indigo-700);
+}
+
+.calendario-opciones-menu {
+  position: absolute;
+  top: 100%; /* Se posiciona justo debajo del botón principal */
+  left: 50%;
+  transform: translateX(-50%); /* Centra el menú debajo del botón */
+  background-color: var(--color-white);
+  border: 1px solid var(--border-color-default);
+  border-radius: 6px;
+  box-shadow: var(--shadow-lg);
+  padding: 8px;
+  margin-top: 8px; /* Pequeño espacio entre el botón y el menú */
+  z-index: 10; /* Para que aparezca sobre otros elementos si es necesario */
+  display: flex;
+  flex-direction: column;
+  gap: 8px; /* Espacio entre las opciones del menú */
+  min-width: 200px; /* Ancho mínimo para el menú */
+}
+
+.opcion-calendario {
+  background-color: transparent;
+  color: var(--color-gray-700);
+  padding: 8px 12px;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  text-align: left;
+  cursor: pointer;
+  font-size: 0.95em;
+  width: 100%;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.opcion-calendario:hover {
+  background-color: var(--color-indigo-50);
+  color: var(--color-indigo-600);
+}


### PR DESCRIPTION
Implementé la funcionalidad que te permite añadir los detalles de tu reserva a tus calendarios personales después de una confirmación exitosa.

Características principales:
- Un botón "Añadir a Calendario" aparece tras una reserva exitosa en el Paso 4.
- Al hacer clic, se despliega un menú con dos opciones:
  1. "Google Calendar": Abre una URL pre-llenada para crear un evento en Google Calendar.
  2. "Otros Calendarios (.ics)": Descarga un archivo .ics universalmente compatible.
- Ambas opciones generan los detalles del evento (título, fechas/horas UTC, descripción, ubicación) basados en la reserva.
- Manejo reservas de múltiples días (discretos o rango) añadiendo una nota en la descripción del evento y creando el evento para la primera fecha.
- Añadí estilos CSS básicos para el botón y el menú desplegable.

Esto mejora tu experiencia al facilitar el seguimiento de tus reservas.