### PR TITLE
Refactor: Increased timeout before resetting after successful booking

### DIFF
--- a/src/components/Paso4_DatosYResumen.jsx
+++ b/src/components/Paso4_DatosYResumen.jsx
@@ -527,7 +527,7 @@ function Paso4_DatosYResumen(props) {
           }
           // setIsSubmitting(false); // onReservationSuccess navega, por lo que el estado de este componente se pierde.
                               // Si no navegara, sería necesario.
-        }, 4000); // 4 segundos para leer el mensaje
+        }, 6000); // 6 segundos para leer el mensaje y usar "Añadir a Calendario"
         // --- Fin: Modificación para manejo temporal sin pasarela de pago ---
 
       } else {


### PR DESCRIPTION
The duration of the `setTimeout` in `Paso4_DatosYResumen.jsx` was increased from 4 to 6 seconds.

This change gives you more time to interact with the "Add to Calendar" button after a booking is successfully completed and before the page flow restarts for a new booking.