### PR TITLE
feat: Implement dual payment method selection

### DIFF
--- a/src/components/Paso4_DatosYResumen.css
+++ b/src/components/Paso4_DatosYResumen.css
@@ -321,3 +321,80 @@
   background-color: var(--color-indigo-50);
   color: var(--color-indigo-600);
 }
+
+/* Estilos para el selector de método de pago */
+.metodo-pago-selector {
+  margin-top: 2rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid #e0e0e0;
+}
+
+.metodo-pago-selector h3 {
+  margin-bottom: 1rem;
+  font-size: 1.2rem;
+  color: #333;
+}
+
+.radio-group-pago {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.radio-group-pago label {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 15px;
+  border: 2px solid #ccc;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: all 0.2s ease-in-out;
+}
+
+.radio-group-pago label:hover {
+  border-color: #007bff;
+}
+
+.radio-group-pago label.selected {
+  border-color: #007bff;
+  background-color: #e7f1ff;
+  font-weight: 500;
+}
+
+.radio-group-pago input[type="radio"] {
+  /* Ocultar el radio button por defecto */
+  appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  width: 20px;
+  height: 20px;
+  border: 2px solid #ccc;
+  border-radius: 50%;
+  outline: none;
+  cursor: pointer;
+  position: relative; /* Para el punto interior */
+}
+
+.radio-group-pago label.selected input[type="radio"] {
+  border-color: #007bff;
+}
+
+/* Crear el punto interior con ::after */
+.radio-group-pago input[type="radio"]::after {
+  content: '';
+  display: block;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background-color: #007bff;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%) scale(0); /* Oculto por defecto */
+  transition: transform 0.2s ease-in-out;
+}
+
+.radio-group-pago input[type="radio"]:checked::after {
+  transform: translate(-50%, -50%) scale(1); /* Visible cuando está seleccionado */
+}


### PR DESCRIPTION
Adds a payment method selector in the final checkout step, allowing users to choose between 'Pagar con Tarjeta' and 'Pagar por Transferencia'.

- Refactors the `handleSubmit` function to conditionally handle either the Mercado Pago payment gateway flow or a standard reservation confirmation for bank transfers.
- Adds a `metodo_pago` field to the reservation creation payload to inform the backend of the user's choice.
- Updates the UI with radio buttons for selection and styles for a clear user experience.