### PR TITLE
fix(checkout): Add required paymentMethods to Payment Brick

### DIFF
--- a/src/components/Paso4_DatosYResumen.jsx
+++ b/src/components/Paso4_DatosYResumen.jsx
@@ -124,6 +124,10 @@ function Paso4_DatosYResumen(props) {
           },
           customization: {
             visual: { style: { theme: 'default' } },
+            paymentMethods: {
+              creditCard: "all",
+              debitCard: "all",
+            },
           },
           callbacks: {
             onReady: () => console.log('Payment Brick está listo.'),


### PR DESCRIPTION
The Mercado Pago Payment Brick was failing to initialize with a 'No payment type was selected' error. This was caused by the absence of the `paymentMethods` configuration in the brick's settings.

This commit adds the `customization.paymentMethods` property to the settings object, explicitly enabling `creditCard` and `debitCard` payments. This resolves the initialization error and allows the payment form to render correctly.