### PR TITLE
fix(checkout): Round amount for Payment Brick API

### DIFF
--- a/src/components/Paso4_DatosYResumen.jsx
+++ b/src/components/Paso4_DatosYResumen.jsx
@@ -117,7 +117,7 @@ function Paso4_DatosYResumen(props) {
       const renderPaymentBrick = async () => {
         const settings = {
           initialization: {
-            amount: desglosePrecio.total,
+            amount: Math.round(desglosePrecio.total),
             payer: {
               email: clienteEmail,
             },


### PR DESCRIPTION
The Payment Brick initialization was failing with a 400 Bad Request because the `amount` field contained a decimal value (e.g., 19999.72), and the Mercado Pago API requires an integer.

This commit resolves the issue by rounding the total amount using `Math.round()` before passing it to the SDK's initialization settings. This ensures the API receives a valid integer and the payment form can be rendered correctly.