### PR TITLE
fix(checkout): Set Payment Brick locale to Spanish

### DIFF
--- a/src/components/Paso4_DatosYResumen.jsx
+++ b/src/components/Paso4_DatosYResumen.jsx
@@ -118,6 +118,7 @@ function Paso4_DatosYResumen(props) {
         const settings = {
           initialization: {
             amount: Math.round(desglosePrecio.total),
+            locale: 'es-CL',
             payer: {
               email: clienteEmail,
             },


### PR DESCRIPTION
The Mercado Pago Payment Brick was defaulting to English. This commit adds the `locale: 'es-CL'` configuration to the brick's initialization settings. This ensures the payment form, including all labels and placeholders for card details, is rendered in Spanish as intended.