### PR TITLE
fix(i18n): Set root HTML lang attribute to Spanish

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="es">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/png" href="/logo.png" />


### PR DESCRIPTION
The Mercado Pago Payment Brick was defaulting to English despite locale settings. This was likely caused by the SDK inheriting the language from the root HTML element, which was set to `lang="en"`.

This commit changes the attribute to `lang="es"` in `index.html` to correctly declare the application's primary language and ensure third-party SDKs like Mercado Pago render in the correct locale.