### PR TITLE
feat: Implement advanced checkout with Payment Bricks

### DIFF
--- a/src/components/Paso4_DatosYResumen.jsx
+++ b/src/components/Paso4_DatosYResumen.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import api, { iniciarPago, procesarPago } from '../api'; // Importar iniciarPago y procesarPago
+import api, { procesarPago } from '../api'; // Importar procesarPago
 import { isSameDay } from 'date-fns'; // Importar isSameDay
 import './Paso4_DatosYResumen.css';
 
@@ -170,7 +170,7 @@ function Paso4_DatosYResumen(props) {
                   reservaId: reservaPrincipal.id,
                 };
 
-                const responsePago = await procesarPago(datosParaBackend);
+                await procesarPago(datosParaBackend);
 
                 // Si llegamos aquí, el pago fue exitoso (o al menos aceptado para procesar)
                 window.location.href = '/pago-exitoso';

--- a/src/components/ReservasManager.jsx
+++ b/src/components/ReservasManager.jsx
@@ -245,17 +245,6 @@ function ReservasManager() {
     }
   };
   
-  const handleCancelReserva = async (reservaId) => {
-    if (!window.confirm(`¿Estás seguro de que deseas cancelar la reserva con ID ${reservaId}?`)) return;
-    try { 
-      await api.delete(`/reservas/${reservaId}`); 
-      fetchReservas(currentPage);
-    } catch (err) { 
-      console.error(`Error al cancelar la reserva ${reservaId}:`, err); 
-      setError(`Error al cancelar la reserva: ${err.response?.data?.error || 'Error del servidor'}`);
-    } 
-  };
-  
   if (loading) return <p>Cargando reservas...</p>;
 
   return (


### PR DESCRIPTION
This commit introduces a complete overhaul of the payment system, replacing the previous redirection method with the Mercado Pago Payment Brick SDK. It also adds dual payment method functionality and several UX improvements.

- **Payment Method Choice:** A radio button group has been added to allow users to select between 'Pagar con Tarjeta' and 'Pagar por Transferencia'.
- **Payment Brick Integration:**
    - The Mercado Pago SDK v2 is added to `index.html`.
    - A `useEffect` hook now manages the lifecycle of the Payment Brick, rendering it when 'Pagar con Tarjeta' is selected.
    - The brick is correctly initialized with the public key, amount (rounded to an integer), and locale set to 'es-CL'.
    - The brick's `onSubmit` callback now handles the entire payment process: it first creates the reservation via the `/reservas` endpoint, then processes the payment with the tokenized data via the `/pagos/procesar-pago` endpoint.
- **UX Fixes:**
    - The main 'Finalizar Reserva' button is now disabled when card payment is chosen, deferring the action to the button inside the brick.
    - The button is also disabled after a successful transfer reservation to prevent accidental re-submission.