### PR TITLE
fix(checkout): Prevent duplicate Payment Brick rendering on email input

### DIFF
--- a/src/components/Paso4_DatosYResumen.jsx
+++ b/src/components/Paso4_DatosYResumen.jsx
@@ -205,8 +205,10 @@ function Paso4_DatosYResumen(props) {
         window.paymentBrick = null; // Limpiar la referencia
       }
     };
-    // Dependencias del efecto: se volverá a ejecutar si cambia el método de pago, el total o el email.
-  }, [metodoPago, desglosePrecio.total, clienteEmail]);
+    // Dependencias del efecto: se volverá a ejecutar si cambia el método de pago o el total.
+    // El email se saca de las dependencias para evitar que el brick se re-renderice en cada tipeo.
+    // El email correcto y actualizado se usa en el callback `onSubmit`.
+  }, [metodoPago, desglosePrecio.total]);
 
 
   const [notasAdicionales, setNotasAdicionales] = useState('');


### PR DESCRIPTION
The Payment Brick was being re-initialized on every keystroke in the email field, causing multiple instances of the form to be stacked in the DOM. This was caused by including `clienteEmail` in the `useEffect` dependency array that manages the brick's lifecycle.

This commit removes `clienteEmail` from the dependency array. The brick is now only rendered when the payment method or the total amount changes. The correct, updated email is still sent during the final submission, as the `onSubmit` callback reads directly from the component's state.