### PR TITLE
fix: Translate chatbot UI and add fallback message

### DIFF
--- a/src/components/Chatbot.jsx
+++ b/src/components/Chatbot.jsx
@@ -23,13 +23,18 @@ const Chatbot = () => {
             return 'show_salones';
           case 'Necesito más información':
             return 'info';
+          default:
+            return 'unrecognized_input';
         }
-        return 'start';
       },
     },
     info: {
         message: 'Puedes encontrar toda la información sobre nuestras salas en la página principal. Si tienes alguna pregunta específica, no dudes en consultarme.',
         end: true,
+    },
+    unrecognized_input: {
+        message: "Lo siento, no te he entendido. Por favor, elige una de las opciones.",
+        path: 'start'
     },
     show_salones: {
       message: 'Claro, aquí tienes nuestras salas. Haz clic en la que te interese.',
@@ -49,8 +54,20 @@ const Chatbot = () => {
     }
   };
 
+  const settings = {
+    header: {
+      title: "Asistente Virtual",
+    },
+    tooltip: {
+        text: "¡Hola! ¿Necesitas ayuda?",
+    },
+    chatInput: {
+        enabledPlaceholderText: "Escribe tu mensaje...",
+    }
+  }
+
   return (
-      <ChatBot flow={flow} />
+      <ChatBot flow={flow} settings={settings} />
   );
 };
 


### PR DESCRIPTION
This commit addresses user feedback on the initial chatbot implementation.

Key changes include:
- The chatbot's header title, input placeholder, and tooltip have been translated to Spanish using the library's `settings` prop.
- A fallback mechanism has been added to the conversation flow. If the chatbot does not understand the user's input, it will now respond with a helpful message instead of getting stuck.