### PR TITLE
fix: Implement API authentication for tool calls

### DIFF
--- a/src/components/Chatbot.jsx
+++ b/src/components/Chatbot.jsx
@@ -21,11 +21,18 @@ const Chatbot = () => {
     }
 
     try {
+      // Get auth token from localStorage
+      const authToken = localStorage.getItem('authToken');
+      const headers = {
+        'Content-Type': 'application/json',
+      };
+      if (authToken) {
+        headers['Authorization'] = `Bearer ${authToken}`;
+      }
+
       const response = await fetch('/api/chat', {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: headers,
         // Send both the current message and the transformed history
         body: JSON.stringify({ message: userInput, history: transformedHistory }),
       });


### PR DESCRIPTION
This commit resolves a critical bug where the chatbot's tool-calling was failing due to unauthenticated requests to the Render API.

The `api/chat.js` backend now correctly receives the user's `authToken` from the frontend and uses it to make authenticated server-to-server requests to the Render API. The frontend `Chatbot.jsx` has also been updated to read this token from `localStorage` and send it with every request.

This change enables the chatbot to securely interact with the protected API endpoints, allowing it to fetch real-time data like the list of rooms and their availability.