### PR TITLE
fix: Implement advanced reasoning logic for chatbot

### DIFF
--- a/api/chat.js
+++ b/api/chat.js
@@ -7,8 +7,8 @@ const backendApi = axios.create({
   baseURL: RENDER_API_URL,
 });
 
+
 // --- Tool Implementations ---
-// The tool functions now accept an authToken to make authenticated requests.
 async function getSalones(args, authToken) {
   try {
     const config = authToken ? { headers: { Authorization: authToken } } : {};
@@ -33,39 +33,58 @@ async function verificarDisponibilidadDiaria({ espacio_id, fecha }, authToken) {
   }
 }
 
+async function getCurrentDate() {
+  // This tool helps the model understand relative dates like "today" or "tomorrow".
+  // NOTE: This uses the server's date. For users in different timezones, this might be off.
+  // For a more robust solution, the user's timezone should be passed from the frontend.
+  const today = new Date();
+  const tomorrow = new Date(today);
+  tomorrow.setDate(tomorrow.getDate() + 1);
+
+  return {
+    today: today.toISOString().split('T')[0], // YYYY-MM-DD
+    tomorrow: tomorrow.toISOString().split('T')[0], // YYYY-MM-DD
+  };
+}
+
+
 // --- Tool Definitions for Gemini ---
 const toolDefinitions = [
-  { name: "getSalones", description: "Obtiene la lista de todos los salones (salas) disponibles para reservar.", parameters: { type: "OBJECT", properties: {} } },
-  { name: "verificarDisponibilidadDiaria", description: "Verifica la disponibilidad de un salón específico en una fecha concreta.", parameters: { type: "OBJECT", properties: { espacio_id: { type: "STRING" }, fecha: { type: "STRING", description: "Formato YYYY-MM-DD." } }, required: ["espacio_id", "fecha"] } }
+  { name: "getSalones", description: "Obtiene la lista de todos los salones (salas) disponibles para reservar, incluyendo sus IDs." },
+  { name: "verificarDisponibilidadDiaria", description: "Verifica la disponibilidad de un salón específico en una fecha concreta.", parameters: { type: "OBJECT", properties: { espacio_id: { type: "STRING" }, fecha: { type: "STRING", description: "La fecha en formato YYYY-MM-DD." } }, required: ["espacio_id", "fecha"] } },
+  { name: "getCurrentDate", description: "Devuelve la fecha actual ('today') y la de mañana ('tomorrow') en formato YYYY-MM-DD. Úsala para resolver fechas relativas." }
 ];
 
-const functionHandlers = { getSalones, verificarDisponibilidadDiaria };
+const functionHandlers = { getSalones, verificarDisponibilidadDiaria, getCurrentDate };
+
 
 // --- Main Handler ---
 export default async function handler(request, response) {
   if (request.method !== 'POST') {
     return response.status(405).json({ error: 'Method Not Allowed' });
   }
-
   if (!process.env.GEMINI_API_KEY || !process.env.RENDER_API_URL) {
     return response.status(500).json({ error: 'AI or API service not configured.' });
   }
 
-  // Extract the auth token from the request headers
   const authToken = request.headers.authorization;
+  const genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY);
+  const model = genAI.getGenerativeModel({
+    model: "gemini-1.5-flash-latest",
+    systemInstruction: `Eres Al-An, un asistente de reservas de salas. Eres amable y muy conciso.
+    **Proceso Obligatorio de Razonamiento:**
+    1.  Si el usuario pregunta por disponibilidad de una sala por su nombre (ej: 'sala grande'), TU PRIMERA ACCIÓN DEBE SER usar la herramienta 'getSalones' para obtener su ID. NO le pidas el ID al usuario.
+    2.  Si el usuario usa una fecha relativa (ej: 'hoy', 'mañana'), TU PRIMERA ACCIÓN DEBE SER usar la herramienta 'getCurrentDate' para obtener la fecha exacta en formato YYYY-MM-DD.
+    3.  Una vez que tengas el 'espacio_id' y la 'fecha' exacta, usa la herramienta 'verificarDisponibilidadDiaria'.
+    4.  Responde al usuario basándote en la información de las herramientas. No inventes información.`,
+    tools: [{ functionDeclarations: toolDefinitions }],
+  });
+
+  const { message, history = [] } = request.body;
+  if (!message) return response.status(400).json({ error: 'Message is required' });
 
   try {
-    const genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY);
-    const model = genAI.getGenerativeModel({
-      model: "gemini-1.5-flash-latest",
-      systemInstruction: "Eres Al-An, un asistente virtual para un servicio de reserva de salas. Eres amable, servicial y muy conciso. Ve directo al punto. No inventes información. Si necesitas datos, debes usar las herramientas que tienes a tu disposición.",
-      tools: [{ functionDeclarations: toolDefinitions }],
-    });
-
-    const { message, history = [] } = request.body;
-    if (!message) return response.status(400).json({ error: 'Message is required' });
-
-    const chat = model.startChat({ history: history });
+    const chat = model.startChat({ history });
     const result = await chat.sendMessage(message);
     const aiResponse = result.response;
     const functionCalls = aiResponse.functionCalls();
@@ -75,7 +94,6 @@ export default async function handler(request, response) {
       for (const call of functionCalls) {
         const handler = functionHandlers[call.name];
         if (handler) {
-          // Pass the authToken to the handler
           const toolResult = await handler(call.args, authToken);
           responses.push({ functionResponse: { name: call.name, response: toolResult } });
         }


### PR DESCRIPTION
This commit addresses a core reasoning failure in the AI chatbot. The chatbot was unable to resolve relative dates (e.g., "tomorrow") and was not correctly following a multi-step process to answer user queries (e.g., get salon ID, then check availability).

This has been fixed by:
1.  Adding a new `getCurrentDate` tool that provides the model with the current date, allowing it to resolve relative date references.
2.  Rewriting the system prompt to enforce a strict, explicit reasoning process. The AI is now instructed to always use its tools to find necessary information (like salon IDs or the current date) before attempting to answer a question about availability.

These changes should result in a significantly more intelligent, capable, and useful assistant.