### PR TITLE
fix: Remove authentication from public tool call

### DIFF
--- a/api/chat.js
+++ b/api/chat.js
@@ -9,10 +9,10 @@ const backendApi = axios.create({
 
 
 // --- Tool Implementations ---
-async function getSalones(args, authToken) {
+async function getSalones() {
   try {
-    const config = authToken ? { headers: { Authorization: authToken } } : {};
-    const response = await backendApi.get('/espacios', config);
+    // This is a public endpoint, so we don't send the auth token.
+    const response = await backendApi.get('/espacios');
     return response.data;
   } catch (error) {
     return { error: `Error al obtener los salones: ${error.message}` };


### PR DESCRIPTION
This commit resolves the final issue preventing the chatbot from using its tools correctly.

The `getSalones` tool was failing because it was sending an `Authorization` header to a public API endpoint (`/espacios`) that does not expect one. This caused the API to reject the request.

The fix removes the authentication logic specifically from the `getSalones` function. Other tools that require authentication, like `verificarDisponibilidadDiaria`, will continue to send the token correctly.

This change allows the chatbot's reasoning chain to execute successfully, as it can now fetch the public list of rooms before proceeding to check their availability.