### PR TITLE
fix: Use hardcoded URL for tool call to debug environment

### DIFF
--- a/api/chat.js
+++ b/api/chat.js
@@ -11,10 +11,12 @@ const backendApi = axios.create({
 // --- Tool Implementations ---
 async function getSalones() {
   try {
-    // This is a public endpoint, so we don't send the auth token.
-    const response = await backendApi.get('/espacios');
+    // Final debugging step: Use axios directly with the full URL to rule out base URL/config issues.
+    const response = await axios.get('https://apialan-api.onrender.com/api/espacios');
     return response.data;
   } catch (error) {
+    // Log the full error to see more details if possible
+    console.error("Critical Error in getSalones tool:", error.toJSON ? error.toJSON() : error);
     return { error: `Error al obtener los salones: ${error.message}` };
   }
 }


### PR DESCRIPTION
This commit is a final debugging attempt to resolve a persistent issue with the `getSalones` tool failing.

The `getSalones` function in `api/chat.js` has been modified to use a hardcoded, absolute URL (`https://apialan-api.onrender.com/api/espacios`) with a direct `axios.get` call. This completely bypasses the configured `axios` instance and the `RENDER_API_URL` environment variable.

The purpose of this change is to isolate the problem. If this call succeeds, it indicates an issue with the environment variable or the `axios` instance configuration. If it still fails, it confirms the problem lies outside the application code, likely in network connectivity between Vercel and Render or the Render API's status itself.