### PR TITLE
fix: Correct API paths for tool-calling

### DIFF
--- a/api/chat.js
+++ b/api/chat.js
@@ -3,7 +3,8 @@ import { GoogleGenerativeAI } from '@google/generative-ai';
 // --- Tool Implementations using native fetch ---
 async function getSalones() {
   try {
-    const response = await fetch('https://apialan-api.onrender.com/api/espacios');
+    // Corrected to use the base URL from env var and the full path here.
+    const response = await fetch(`${process.env.RENDER_API_URL}/api/espacios`);
     if (!response.ok) {
       throw new Error(`Network response was not ok: ${response.statusText}`);
     }
@@ -16,7 +17,7 @@ async function getSalones() {
 
 async function verificarDisponibilidadDiaria({ espacio_id, fecha }, authToken) {
   try {
-    const url = new URL(`https://apialan-api.onrender.com/api/reservas`);
+    const url = new URL(`${process.env.RENDER_API_URL}/api/reservas`);
     url.searchParams.append('espacio_id', espacio_id);
     url.searchParams.append('fecha', fecha);
 


### PR DESCRIPTION
This commit corrects the API paths used by the tool-calling functions in `api/chat.js`.

Based on user feedback, the `RENDER_API_URL` environment variable should contain only the base URL (e.g., `https://host.com`), and the API paths (`/api/espacios`, `/api/reservas`) should be appended in the code.

This change implements that logic, ensuring the final request URLs are constructed correctly. This should resolve the persistent 500 error and allow the chatbot's tools to function as intended.