### PR TITLE
feat: Autofill billing information for partners

### DIFF
--- a/src/components/Paso4_DatosYResumen.jsx
+++ b/src/components/Paso4_DatosYResumen.jsx
@@ -21,6 +21,11 @@ function Paso4_DatosYResumen(props) {
     rutSocio,
     nombreSocioAutofill,
     emailSocioAutofill,
+    // --- Nuevas props para datos de facturación de socio ---
+    rutEmpresaAutofill,
+    razonSocialAutofill,
+    giroAutofill,
+    direccionComercialAutofill,
     codigoCuponInput,
     setCodigoCuponInput,
     cuponAplicado,
@@ -110,6 +115,20 @@ function Paso4_DatosYResumen(props) {
       setMensajeSocio('');
     }
   }, [nombreSocioAutofill, emailSocioAutofill, rutSocio, esSocio, clienteNombre, clienteEmail]);
+
+  // --- Efecto para autocompletar datos de facturación para socios ---
+  React.useEffect(() => {
+    // Si es socio, se ha seleccionado 'factura' y hay datos de la empresa para autocompletar
+    if (esSocio && tipoDocumento === 'factura' && rutEmpresaAutofill) {
+      setFacturacionRut(rutEmpresaAutofill);
+      setFacturacionRazonSocial(razonSocialAutofill || '');
+      setFacturacionGiro(giroAutofill || '');
+      setFacturacionDireccion(direccionComercialAutofill || '');
+    }
+    // Opcional: ¿Qué hacer si cambian de 'factura' a 'boleta'?
+    // Por ahora, no se limpian los campos para no perder datos si el usuario cambia de opinión.
+    // El backend solo los usará si tipoDocumento es 'factura'.
+  }, [esSocio, tipoDocumento, rutEmpresaAutofill, razonSocialAutofill, giroAutofill, direccionComercialAutofill]);
 
   // --- Efecto para el Payment Brick de Mercado Pago ---
   React.useEffect(() => {

--- a/src/pages/BookingPage.jsx
+++ b/src/pages/BookingPage.jsx
@@ -303,6 +303,11 @@ function BookingPage() {
             rutSocio={socioData ? socioData.rut : null}
             nombreSocioAutofill={socioData ? socioData.nombre_completo : ''}
             emailSocioAutofill={socioData ? socioData.email : ''}
+            // --- Nuevas props para autocompletar datos de facturación ---
+            rutEmpresaAutofill={socioData ? socioData.rut_empresa : ''}
+            razonSocialAutofill={socioData ? socioData.razon_social : ''}
+            giroAutofill={socioData ? socioData.giro : ''}
+            direccionComercialAutofill={socioData ? socioData.direccion_comercial : ''}
             onSocioDataChange={setSocioData}
             // Props para cupones
             codigoCuponInput={codigoCuponInput}


### PR DESCRIPTION
When a validated partner selects 'factura' as the document type in step 4 of the booking process, this change automatically fills in the billing information fields (company RUT, business name, business activity, and commercial address).

- Modified `BookingPage.jsx` to pass the partner's company data down to the `Paso4_DatosYResumen.jsx` component.
- Updated `Paso4_DatosYResumen.jsx` to include a `useEffect` hook that listens for changes in the document type and partner status, triggering the autofill functionality.