### PR TITLE
Feat: Enable Saturday bookings in the frontend calendar

### DIFF
--- a/src/components/CustomCalendar.jsx
+++ b/src/components/CustomCalendar.jsx
@@ -96,8 +96,8 @@ function CustomCalendar({
     let isDisabled = false;
 
     const dayOfWeek = currentDate.getDay();
-    // Deshabilitar fechas pasadas y fines de semana (Domingo=0, Sábado=6)
-    if (currentDate < today || dayOfWeek === 0 || dayOfWeek === 6) {
+    // Deshabilitar fechas pasadas y domingos (Domingo=0)
+    if (currentDate < today || dayOfWeek === 0) {
       dayClass += ' disabled';
       isDisabled = true;
     }
@@ -293,7 +293,7 @@ function CustomCalendar({
     const dayOfWeek = currentDate.getDay();
     let isPastDate = currentDate < todayForComparison;
 
-    if (isPastDate || dayOfWeek === 0 || dayOfWeek === 6) {
+    if (isPastDate || dayOfWeek === 0) {
       dayClass += ' disabled';
       isDisabled = true;
     }


### PR DESCRIPTION
This commit updates the frontend calendar to allow users to select Saturdays for bookings, aligning with the new business logic where Saturday reservations are permitted.

The `CustomCalendar.jsx` component was modified to remove the logic that disabled Saturdays (`dayOfWeek === 6`). The logic to disable Sundays (`dayOfWeek === 0`) and past dates remains unchanged.